### PR TITLE
Fixing auto-invite to use formdata, adding bot reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Settings
+settings.js
+
+# OS hidden files
+.DS_Store

--- a/bin/www
+++ b/bin/www
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var app = require('../main');
 
 var server = app.listen(8081, function() {

--- a/helpers/slack.js
+++ b/helpers/slack.js
@@ -1,14 +1,15 @@
-var Qs = require('qs');
-
 module.exports = {
   getProps: function(member, extra) {
     requestProps = {}
-    requestProps.url = 'https://' + member.team + '.slack.com/api/users.admin.invite';
+    var apiUrl = 'https://' + member.team + '.slack.com/api/';
+    requestProps.inviteUrl = apiUrl + 'users.admin.invite';
+    requestProps.channelUrl = apiUrl + 'chat.postMessage?';
 
     requestProps.form = {
       t: (new Date).getTime(),
       token: process.env.SLACK_TOKEN,
-      first_name: member.name,
+      first_name: member.name.split(' ')[0],
+      last_name: member.name.split(' ').slice(1),
       email: member.email,
       channels: extra.slack_channels,
       set_active: true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "body-parser": "^1.12.4",
     "express": "^4.12.4",
+    "isomorphic-fetch": "^2.2.1",
     "mongodb": "^1.4.38",
     "mongoskin": "^1.4.13",
     "qs": "^3.1.0",

--- a/routes/postSignup.js
+++ b/routes/postSignup.js
@@ -1,18 +1,72 @@
-var requestLib = require('request'),
-    Member = require('../models/member'),
-    slack = require('../helpers/slack');
+require('isomorphic-fetch');
+var Member = require('../models/member'),
+    slack = require('../helpers/slack'),
+    qs = require('querystring'),
+    settings;
+
+try {
+  settings = require('../settings');
+} catch (e) {
+  console.log('Please create a settings.js file. A sample has been provided in the root directory.');
+  settings = {
+    bot: {
+      reporting: { active: false }
+    }
+  };
+}
 
 module.exports = function(request, response) {
   var member = new Member(request.body.member);
 
   if (member.save()) {
-    // Post to Slack
-    requestLib.post(slack.getProps(member, request.body.extra));
+    var props = slack.getProps(member, request.body.extra);
+    var form = new FormData();
+    form.append('t', props.form.t);
+    form.append('first_name', props.form.first_name);
+    form.append('last_name', props.form.last_name);
+    form.append('email', props.form.email);
+    form.append('token', props.form.token);
+    form.append('set_active', props.form.set_active);
+    form.append('channels', props.form.channels);
 
-    // Redirect to given website
-    response.redirect(302, request.body.extra.redirect_uri);
-  } else {
-    // Send failure status
-    response.status(422).send("Couldn't save member.");
+    fetch(props.inviteUrl, {
+      method: 'POST',
+      body: form
+    })
+      .then(res => {
+        if (res.status >= 200 && res.status < 300) {
+          return res;
+        } else {
+          var error = new Error(response.statusText);
+          error.response = response;
+          throw error;
+        }
+      })
+      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) { throw new Error(res.error); }
+        if (settings.bot.reporting.active) {
+          var data = qs.stringify({
+            token: props.form.token,
+            username: settings.bot.name,
+            channel: settings.bot.reporting.channel,
+            text: `${member.name} [${member.email}] has been invited to Frontend Developers.`
+          });
+          fetch(props.channelUrl + data);
+        }
+        response.redirect(302, request.body.extra.redirect_uri);
+      })
+      .catch(err => {
+        if (settings.bot.reporting.active) {
+          var data = qs.stringify({
+            token: props.form.token,
+            username: settings.bot.name,
+            channel: settings.bot.reporting.channel,
+            text: `An error has occurred attempting to invite ${member.email}. ${err}`
+          });
+          fetch(props.channelUrl + data);
+        }
+        response.status(422).send("Couldn't save member.");
+      });
   }
 };

--- a/settings.sample.js
+++ b/settings.sample.js
@@ -1,0 +1,9 @@
+module.exports = {
+  bot: {
+    name: 'Steve',
+    reporting: {
+      active: false,
+      channel: ""
+    }
+  }
+};


### PR DESCRIPTION
Fixed the auto-invite situation to use form-data since sending json was returning bad email errors no matter what was being sent.  I just snooped on Slack's invite page to see what they were doing and mimicked it.  Also added a little bot reporting tool if you want to use it.  It's inactive by default, but if you create a `settings.js` file in the same style as the sample provided in the root directory, it'll say when it's getting errors and when it's successfully inviting people.
